### PR TITLE
Fix move selection for line/freehand, bump v1.1.1

### DIFF
--- a/.mise.local.toml
+++ b/.mise.local.toml
@@ -1,2 +1,2 @@
 [tools]
-flutter = "3.38.7"
+flutter = "3.41.6"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.1
+
+- Fix: Corrected move selection hit detection for `line` and `freehand` drawing objects.
+- Chore: Updated toolchain and example iOS configuration.
+
 # 1.1.0
 
 - Feat: Support for removing specific drawing objects via a contextual delete menu (triggered by long-press).

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,28 +1,21 @@
 PODS:
   - Flutter (1.0.0)
-  - open_file_ios (0.0.1):
+  - open_file_ios (1.0.3):
     - Flutter
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - open_file_ios (from `.symlinks/plugins/open_file_ios/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   open_file_ios:
     :path: ".symlinks/plugins/open_file_ios/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  open_file_ios: 461db5853723763573e140de3193656f91990d9e
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  open_file_ios: ece9c5358aec7b7ed7dc12fcb0f926ef6d6650f1
 
 PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
 

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -179,18 +179,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -408,10 +408,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/issues/bug-line-freehand-not-movable.md
+++ b/issues/bug-line-freehand-not-movable.md
@@ -1,0 +1,25 @@
+# Bug: line/freehand objects cannot be moved by drag
+
+## Summary
+Line and freehand drawing objects cannot be moved via drag after selection. Other shapes can be moved as expected.
+
+## Environment
+- Package: image_painter_rotate
+- App: example
+- Flutter: stable (per README)
+
+## Steps to Reproduce
+1. Open the example app.
+2. Draw a Line.
+3. Tap to select the line (marching ants appears).
+4. Drag the selected line.
+5. Repeat with Freehand.
+
+## Expected
+Selected line/freehand objects move with the drag gesture (same as rectangle/circle/etc).
+
+## Actual
+Line/freehand objects do not move; drag has no effect.
+
+## Notes
+- Likely related to selection hit-testing or move offset application for these modes.

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -260,9 +261,15 @@ class ImagePainterController extends ChangeNotifier {
         return _isCircleSelected(item, offset);
       case PaintMode.text:
         return _isTextSelected(item, offset);
+      case PaintMode.freeStyle:
+        return _isFreeStyleSelected(item, offset);
       default:
         return false;
     }
+  }
+
+  double _selectionTolerance(PaintInfo item) {
+    return math.max(16, item.strokeWidth * 2);
   }
 
   bool _isRectSelected(PaintInfo item, Offset offset) {
@@ -273,13 +280,43 @@ class ImagePainterController extends ChangeNotifier {
   bool _isLineSelected(PaintInfo item, Offset offset) {
     final p1 = item.offsets[0]!;
     final p2 = item.offsets[1]!;
-    final distance = ((p2.dx - p1.dx) * (p1.dy - offset.dy) -
-                (p1.dx - offset.dx) * (p2.dy - p1.dy))
-            .abs() /
-        (p2 - p1).distance;
-    return distance < 10;
+    return _isLineSegmentSelected(p1, p2, offset, _selectionTolerance(item));
   }
 
+  bool _isFreeStyleSelected(PaintInfo item, Offset offset) {
+    final points = item.offsets;
+    final tolerance = _selectionTolerance(item);
+    for (int i = 0; i < points.length - 1; i++) {
+      final current = points[i];
+      final next = points[i + 1];
+      if (current != null && next != null) {
+        if (_isLineSegmentSelected(current, next, offset, tolerance)) {
+          return true;
+        }
+      } else if (current != null && next == null) {
+        if ((offset - current).distance <= tolerance) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool _isLineSegmentSelected(
+      Offset p1, Offset p2, Offset point, double tolerance) {
+    final dx = p2.dx - p1.dx;
+    final dy = p2.dy - p1.dy;
+    final lengthSquared = dx * dx + dy * dy;
+    if (lengthSquared == 0) {
+      return (point - p1).distance <= tolerance;
+    }
+    final t = ((point.dx - p1.dx) * dx + (point.dy - p1.dy) * dy) /
+        lengthSquared;
+    final clampedT = t.clamp(0.0, 1.0) as double;
+    final projection =
+        Offset(p1.dx + clampedT * dx, p1.dy + clampedT * dy);
+    return (point - projection).distance <= tolerance;
+  }
   bool _isCircleSelected(PaintInfo item, Offset offset) {
     final center = item.offsets[1]!;
     final radius = (item.offsets[0]! - item.offsets[1]!).distance;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -275,14 +275,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -327,18 +319,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -524,26 +516,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: image_painter_rotate
 description: A powerful Flutter widget for painting over images. Supports rotation, shapes, text, undo/redo, object removal, and image export capabilities.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/satoyan/yellowQ-Flutter-Image-Painter
 
 environment:

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -75,5 +75,51 @@ void main() {
 
       expect(controller.paintHistory.length, 0);
     });
+
+    test('detectObject selects line within tolerance and near endpoint', () {
+      final controller = ImagePainterController();
+      final line = PaintInfo(
+        mode: PaintMode.line,
+        color: Colors.black,
+        strokeWidth: 1.0,
+        offsets: [const Offset(0, 0), const Offset(100, 0)],
+      );
+
+      controller.addPaintInfo(line);
+
+      expect(controller.detectObject(const Offset(50, 12)), line);
+      controller.deselectAll();
+
+      expect(controller.detectObject(const Offset(110, 0)), line);
+    });
+
+    test('detectObject selects freeStyle segment', () {
+      final controller = ImagePainterController();
+      final stroke = PaintInfo(
+        mode: PaintMode.freeStyle,
+        color: Colors.black,
+        strokeWidth: 1.0,
+        offsets: [const Offset(0, 0), const Offset(50, 0)],
+      );
+
+      controller.addPaintInfo(stroke);
+
+      expect(controller.detectObject(const Offset(25, 12)), stroke);
+    });
+
+    test('detectObject selects freeStyle point', () {
+      final controller = ImagePainterController();
+      final dot = PaintInfo(
+        mode: PaintMode.freeStyle,
+        color: Colors.black,
+        strokeWidth: 1.0,
+        offsets: [const Offset(10, 10), null],
+      );
+
+      controller.addPaintInfo(dot);
+
+      expect(controller.detectObject(const Offset(20, 10)), dot);
+    });
+
   });
 }


### PR DESCRIPTION
## Summary

- Fix move selection hit detection for `line` and `freehand` drawing objects
- Update toolchain and example iOS configuration
- Bump version to 1.1.1

## Test plan

- [ ] Verify line objects can be selected and moved correctly
- [ ] Verify freehand objects can be selected and moved correctly
- [ ] Confirm undo/redo still works after move

🤖 Generated with [Claude Code](https://claude.ai/claude-code)