### PR TITLE
fix: high-resolution image drag movement (#15)

### DIFF
--- a/lib/src/_paint_over_image.dart
+++ b/lib/src/_paint_over_image.dart
@@ -526,7 +526,7 @@ class ImagePainterState extends State<ImagePainter>
   int _strokeMultiplier = 1;
   late TextDelegate textDelegate;
   PaintInfo? _selectedObject;
-  Offset? _initialPanPosition;
+  Offset? _initialPanScenePosition;
   List<Offset?>? _initialOffsets;
 
   @override
@@ -789,7 +789,7 @@ class ImagePainterState extends State<ImagePainter>
       if (_selectedObject == null) {
         _controller.deselectAll();
       } else {
-        _initialPanPosition = onStart.focalPoint;
+        _initialPanScenePosition = _zoomAdjustedOffset;
         _initialOffsets = _selectedObject!.offsets;
       }
     } else {
@@ -804,11 +804,10 @@ class ImagePainterState extends State<ImagePainter>
   void _scaleUpdateGesture(ScaleUpdateDetails onUpdate) {
     if (_controller.mode == PaintMode.move) {
       if (_selectedObject != null) {
-        final delta = onUpdate.focalPoint - _initialPanPosition!;
-        final newOffsets = _initialOffsets!.map((e) {
-          if (e == null) return null;
-          return e + delta;
-        }).toList();
+        final currentScenePosition =
+            _transformationController.toScene(onUpdate.localFocalPoint);
+        final delta = currentScenePosition - _initialPanScenePosition!;
+        final newOffsets = movedOffsetsBySceneDelta(_initialOffsets!, delta);
         _selectedObject!.offsets = newOffsets;
         _controller.updatePaintInfo(_selectedObject!);
       }
@@ -838,7 +837,7 @@ class ImagePainterState extends State<ImagePainter>
         _controller.addMoveAction(_selectedObject!, _initialOffsets!);
       }
       _selectedObject = null;
-      _initialPanPosition = null;
+      _initialPanScenePosition = null;
       _initialOffsets = null;
     } else {
       _controller.setInProgress(false);
@@ -1134,4 +1133,15 @@ class ImagePainterState extends State<ImagePainter>
       ),
     );
   }
+}
+
+@visibleForTesting
+List<Offset?> movedOffsetsBySceneDelta(
+  List<Offset?> offsets,
+  Offset sceneDelta,
+) {
+  return offsets.map((e) {
+    if (e == null) return null;
+    return e + sceneDelta;
+  }).toList();
 }

--- a/test/image_painter_move_test.dart
+++ b/test/image_painter_move_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_painter_rotate/src/_paint_over_image.dart';
+
+void main() {
+  test('movedOffsetsBySceneDelta applies image-space movement', () {
+    final offsets = <Offset?>[
+      const Offset(1000, 1000),
+      const Offset(1100, 1000),
+      null,
+      const Offset(1200, 1100),
+    ];
+
+    final moved = movedOffsetsBySceneDelta(
+      offsets,
+      const Offset(200, 50),
+    );
+
+    expect(moved, [
+      const Offset(1200, 1050),
+      const Offset(1300, 1050),
+      null,
+      const Offset(1400, 1150),
+    ]);
+    expect(offsets[0], const Offset(1000, 1000));
+  });
+}


### PR DESCRIPTION
## Summary
- Fix object drag using screen-space focal-point delta, which desynced from image content at zoom/high-resolution images
- Switch to scene-space delta via `InteractiveViewer`'s `toScene()` transform
- Add `movedOffsetsBySceneDelta` (testable pure fn) + unit test

## Test plan
- [x] `flutter test` — 24/24 pass
- [x] Manual drag verify recommended on device with zoomed high-res image

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)