### PR TITLE
chore: upgrade example Android build tooling

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -13,10 +12,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/example/android/app/src/main/java/com/example/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/example/MainActivity.java
@@ -1,0 +1,6 @@
+package com.example.example;
+
+import io.flutter.embedding.android.FlutterActivity;
+
+public class MainActivity extends FlutterActivity {
+}

--- a/example/android/app/src/main/kotlin/com/example/example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/example/example/MainActivity.kt
@@ -1,5 +1,0 @@
-package com.example.example
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity: FlutterActivity()

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Summary
- Bump AGP 8.6.0 -> 8.11.1, Kotlin 2.1.0 -> 2.2.20, Gradle wrapper 8.7 -> 8.14 for example app
- Convert example MainActivity from Kotlin to Java, drop now-unused `kotlin-android` app-level plugin application (settings.gradle still declares the plugin version — required by Flutter's own KGP version check, confirmed by testing)
- Resolves Flutter/Gradle toolchain warnings on `flutter build apk`

## Test plan
- [x] `flutter build apk --debug` — clean, no warnings
- [x] `flutter test` (package) — 24/24 pass
- [x] `flutter test` (example) — pre-existing failure in stale template `widget_test.dart` (counter smoke test doesn't match this app's UI), unrelated to this change, also fails on `develop` HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)